### PR TITLE
Remove usage of graceful_shutdown

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,12 @@ fn pid1_handling(settings: &Pid1Settings, child: Option<Child>) -> ! {
                             Ok(()) => std::process::exit(exit_code),
                             Err(errno) => {
                                 if settings.log {
-                                    eprintln!("pid1-rs: kill() failed on {pid} with errno: {errno}");
+                                    eprintln!(
+                                        "pid1-rs: kill() failed on {pid} with errno: {errno}"
+                                    );
                                 }
                                 std::process::exit(exit_code)
-                            },
+                            }
                         }
                     }
                     None => std::process::exit(exit_code),


### PR DESCRIPTION
The usage of abort() calls segmentation issues, so using the exit call in the places.

Also, did some rename of variables so that the readability imrpoves.