### PR TITLE
fix: Remove unnecessary non-PID 1 log output

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  pull_request:
   push:
     tags:
       - '*' # Push events to matching v*, i.e. v1.0, v20.15.10
@@ -15,22 +16,19 @@ env:
 jobs:
   checks:
     runs-on: ${{ matrix.os }}
-
     strategy:
       fail-fast: false
       matrix:
         os:
         - ubuntu-latest
-
         toolchain:
-        - 1.82.0
+        - 1.88.0
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: extractions/setup-just@v1
+    - uses: actions/checkout@4
+    - uses: taiki-e/install-action@v2
       with:
-        just-version: 1.10.0
-    - uses: cargo-bins/cargo-binstall@main
+        tool: just@1.40.0,cross@0.2.5
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.toolchain }}
@@ -41,19 +39,18 @@ jobs:
       run: |
         sudo apt-get install -y musl-tools
         rustup target add x86_64-unknown-linux-musl
-        cargo binstall cross --no-confirm
     - name: Build Musl binary
       run: just build-release-binary
     - name: Build other binaries
       run: just binaries true
     - name: Generate artifacts
       run: just cp-binaries
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: binaries
         path: artifacts/*
     - name: Release
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       if: startsWith(github.ref, 'refs/tags/')
       with:
         files: artifacts/*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
         - 1.88.0
 
     steps:
-    - uses: actions/checkout@4
+    - uses: actions/checkout@v4
     - uses: taiki-e/install-action@v2
       with:
         tool: just@1.40.0,cross@0.2.5

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,15 +27,14 @@ jobs:
         - windows-latest
 
         toolchain:
-        - 1.82.0
+        - 1.88.0
         - stable
         - nightly
-
     steps:
     - uses: actions/checkout@v2
-    - uses: extractions/setup-just@v1
+    - uses: taiki-e/install-action@v2
       with:
-        just-version: 1.10.0
+        tool: just@1.40.0
     - uses: Swatinem/rust-cache@v2
       with:
         key: ${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.toolchain }}
@@ -58,7 +57,5 @@ jobs:
     - name: Run pid1 tests
       run: just test-init-image
       if: runner.os == 'Linux'
-    - name: clippy
-      run: cargo clippy -- --deny "warnings"
-    - name: fmt
-      run: cargo fmt -- --check
+    - name: Lint
+      run: just lint

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,6 @@ jobs:
         - ubuntu-latest
         - macos-latest
         - windows-latest
-
         toolchain:
         - 1.88.0
         - stable
@@ -59,3 +58,4 @@ jobs:
       if: runner.os == 'Linux'
     - name: Lint
       run: just lint
+      if: matrix.toolchain == '1.88.0'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,7 +30,7 @@ jobs:
         - stable
         - nightly
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: taiki-e/install-action@v2
       with:
         tool: just@1.40.0

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,13 +35,13 @@ jobs:
     - uses: taiki-e/install-action@v2
       with:
         tool: just@1.40.0
-    - uses: Swatinem/rust-cache@v2
-      with:
-        key: ${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.toolchain }}
     - uses: dtolnay/rust-toolchain@master
       with:
         toolchain: ${{ matrix.toolchain }}
         components: clippy, rustfmt
+    - uses: Swatinem/rust-cache@v2
+      with:
+        key: ${{ runner.os }}-${{ hashFiles('Cargo.lock') }}-${{ matrix.toolchain }}
     - name: Install musl tools
       run: |
         sudo apt-get install -y musl-tools

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /target
 /etc/simple
+.env
+.envrc

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.1.5
+
+- Bump versions.
+- Remove confusing non PID 1 log message.
+
 # v0.1.4
 
 - Add integration testing

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,21 +13,21 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "backtrace"
-version = "0.3.74"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
 name = "byteorder"
@@ -52,9 +52,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -64,9 +64,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "be92d32e80243a54711e5d7ce823c35c41c9d929dc4ab58e1276f625841aadf9"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -74,9 +74,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "707eab41e9622f9139419d573eca0900137718000c517d47da73045f54331c3d"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -84,9 +84,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "ef4f52386a59ca4c860f7393bcf8abd8dfd91ecccc0f774635ff68e92eeef491"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -96,9 +96,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "getrandom"
@@ -124,24 +124,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "libc"
-version = "0.2.168"
+name = "io-uring"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
+checksum = "b86e202f00093dcba4275d4636b93ef9dd75d025ae560d2521b45ea28ab49013"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "libc"
+version = "0.2.174"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys",
 ]
 
 [[package]]
@@ -158,9 +180,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.5"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
@@ -187,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "ppv-lite86"
@@ -202,18 +224,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.37"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -250,15 +272,15 @@ dependencies = [
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
 
 [[package]]
 name = "signal-hook"
-version = "0.3.17"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
 dependencies = [
  "libc",
  "signal-hook-registry",
@@ -266,18 +288,24 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
 
 [[package]]
-name = "syn"
-version = "2.0.90"
+name = "slab"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
+checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+
+[[package]]
+name = "syn"
+version = "2.0.104"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -306,12 +334,16 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.43.0"
+version = "1.46.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d61fa4ffa3de412bfea335c6ecff681de2b609ba3c77ef3e00e521813a9ed9e"
+checksum = "0cc3a2344dafbe23a245241fe8b09735b521110d30fcefbbd5feb1797ca35d17"
 dependencies = [
  "backtrace",
+ "io-uring",
+ "libc",
+ "mio",
  "pin-project-lite",
+ "slab",
  "tokio-macros",
 ]
 
@@ -328,15 +360,24 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-targets"

--- a/README.md
+++ b/README.md
@@ -84,5 +84,5 @@ Options:
 
 ## Development
 
-The testing steps are documented in [Development.md](./Development.md). We have also
+The testing steps are documented in [Development.md](./Development.md). We also have
 integration tests for the same.

--- a/justfile
+++ b/justfile
@@ -1,86 +1,48 @@
 # List all recipies
 default:
-	just --list --unsorted
+    just --list --unsorted
 
 # Build pid binary
 build-release-binary:
-	cargo build --target x86_64-unknown-linux-musl --release
+    cargo build --target x86_64-unknown-linux-musl --release
 
 # Build test container
 test: build-release-binary
-	cp target/x86_64-unknown-linux-musl/release/pid1 ./pid1-exe/etc/
-	cd pid1-exe/etc && docker build . -f Dockerfile --tag pid1runner
+    cp target/x86_64-unknown-linux-musl/release/pid1 ./pid1-exe/etc/
+    cd pid1-exe/etc && docker build . -f Dockerfile --tag pid1runner
 
 # Test docker image
 test-init-image:
-	docker run --rm --interactive --name pid pid1runner ps aux
-	docker run --rm --interactive --name pid pid1runner ls
-	docker run --rm --interactive --name pid pid1runner ls /
-	docker run --rm --interactive --name pid pid1runner id
-	docker run --rm --interactive --name pid pid1runner --workdir=/home  pwd
-	docker run --rm --interactive --name pid pid1runner --env HELLO=WORLD --env=FOO=BYE printenv HELLO FOO
+    docker run --rm --interactive --name pid pid1runner ps aux
+    docker run --rm --interactive --name pid pid1runner ls
+    docker run --rm --interactive --name pid pid1runner ls /
+    docker run --rm --interactive --name pid pid1runner id
+    docker run --rm --interactive --name pid pid1runner --workdir=/home  pwd
+    docker run --rm --interactive --name pid pid1runner --env HELLO=WORLD --env=FOO=BYE printenv HELLO FOO
 
 # Exec init image
 exec-init-image:
-	docker run --rm --name pid --tty --interactive pid1runner sh
+    docker run --rm --name pid --tty --interactive pid1runner sh
 
 # Build binary for other architectures
 binaries clean='false':
-	cross build --target x86_64-unknown-linux-gnu --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5
-	cross build --target aarch64-unknown-linux-gnu --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5
-	cross build --target aarch64-unknown-linux-musl --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5
-	cross build --target arm-unknown-linux-musleabi --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/arm-unknown-linux-musleabi:0.2.5
-	cross build --target arm-unknown-linux-musleabihf --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/arm-unknown-linux-musleabihf:0.2.5
-	cross build --target armv5te-unknown-linux-musleabi --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/armv5te-unknown-linux-musleabi:0.2.5
-	cross build --target armv7-unknown-linux-musleabi --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/armv7-unknown-linux-musleabi:0.2.5
-	cross build --target armv7-unknown-linux-musleabihf --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/armv7-unknown-linux-musleabihf:0.2.5
-	cross build --target i586-unknown-linux-musl --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/i586-unknown-linux-musl:0.2.5
-	cross build --target i686-unknown-linux-musl --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/i686-unknown-linux-musl:0.2.5
-	cross build --target mips64-unknown-linux-muslabi64 --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/mips64-unknown-linux-muslabi64:0.2.5
-	cross build --target mips64el-unknown-linux-muslabi64 --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/mips64el-unknown-linux-muslabi64:0.2.5
-	cross build --target powerpc-unknown-linux-gnu --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/powerpc-unknown-linux-gnu:0.2.5
-	cross build --target powerpc64-unknown-linux-gnu --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/powerpc64-unknown-linux-gnu:0.2.5
-	cross build --target powerpc64le-unknown-linux-gnu --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/powerpc64le-unknown-linux-gnu:0.2.5
-	cross build --target riscv64gc-unknown-linux-gnu --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/riscv64gc-unknown-linux-gnu:0.2.5
-	cross build --target s390x-unknown-linux-gnu --release
-	-{{clean}} && docker image rm ghcr.io/cross-rs/s390x-unknown-linux-gnu:0.2.5
-
+    cross build --target x86_64-unknown-linux-gnu --release
+    -{{ clean }} && docker image rm ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5
+    cross build --target aarch64-unknown-linux-gnu --release
+    -{{ clean }} && docker image rm ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5
+    cross build --target aarch64-unknown-linux-musl --release
+    -{{ clean }} && docker image rm ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5
 
 # Copy binaries to artifacts directory
 cp-binaries:
-	mkdir -p artifacts
-	cp target/x86_64-unknown-linux-musl/release/pid1  ./artifacts/pid1-x86_64-unknown-linux-musl
-	cp target/x86_64-unknown-linux-gnu/release/pid1 ./artifacts/pid1-x86_64-unknown-linux-gnu
-	cp target/aarch64-unknown-linux-gnu/release/pid1 ./artifacts/pid1-aarch64-unknown-linux-gnu
-	cp target/aarch64-unknown-linux-musl/release/pid1 ./artifacts/pid1-aarch64-unknown-linux-musl
-	cp target/arm-unknown-linux-musleabi/release/pid1 ./artifacts/pid1-arm-unknown-linux-musleabi
-	cp target/arm-unknown-linux-musleabihf/release/pid1 ./artifacts/pid1-arm-unknown-linux-musleabihf
-	cp target/armv5te-unknown-linux-musleabi/release/pid1 ./artifacts/pid1-armv5te-unknown-linux-musleabi
-	cp target/armv7-unknown-linux-musleabi/release/pid1 ./artifacts/pid1-armv7-unknown-linux-musleabi
-	cp target/armv7-unknown-linux-musleabihf/release/pid1 ./artifacts/pid1-armv7-unknown-linux-musleabihf
-	cp target/i586-unknown-linux-musl/release/pid1 ./artifacts/pid1-i586-unknown-linux-musl
-	cp target/i686-unknown-linux-musl/release/pid1 ./artifacts/pid1-i686-unknown-linux-musl
-	cp target/mips64-unknown-linux-muslabi64/release/pid1 ./artifacts/pid1-mips64-unknown-linux-muslabi64
-	cp target/mips64el-unknown-linux-muslabi64/release/pid1 ./artifacts/pid1-mips64el-unknown-linux-muslabi64
-	cp target/powerpc-unknown-linux-gnu/release/pid1 ./artifacts/pid1-powerpc-unknown-linux-gnu
-	cp target/powerpc64-unknown-linux-gnu/release/pid1 ./artifacts/pid1-powerpc64-unknown-linux-gnu
-	cp target/powerpc64le-unknown-linux-gnu/release/pid1 ./artifacts/pid1-powerpc64le-unknown-linux-gnu
-	cp target/riscv64gc-unknown-linux-gnu/release/pid1 ./artifacts/pid1-riscv64gc-unknown-linux-gnu
-	cp target/s390x-unknown-linux-gnu/release/pid1 ./artifacts/pid1-s390x-unknown-linux-gnu
-	file artifacts/*
+    mkdir -p artifacts
+    cp target/x86_64-unknown-linux-musl/release/pid1  ./artifacts/pid1-x86_64-unknown-linux-musl
+    cp target/x86_64-unknown-linux-gnu/release/pid1 ./artifacts/pid1-x86_64-unknown-linux-gnu
+    cp target/aarch64-unknown-linux-gnu/release/pid1 ./artifacts/pid1-aarch64-unknown-linux-gnu
+    cp target/aarch64-unknown-linux-musl/release/pid1 ./artifacts/pid1-aarch64-unknown-linux-musl
+    file artifacts/*
+
+# Lint
+lint:
+	cargo clippy -- --deny "warnings"
+	cargo fmt -- --check

--- a/pid1-exe/Cargo.toml
+++ b/pid1-exe/Cargo.toml
@@ -13,8 +13,8 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 pid1 = { path = "../pid1", version = "0.1.1" }
-signal-hook = "0.3.17"
-clap = { version = "4.5.26", default-features = false, features = ["std", "derive", "help"]}
+signal-hook = "0.3.18"
+clap = { version = "4.5.41", default-features = false, features = ["std", "derive", "help"]}
 
 [[bin]]
 name = "pid1"

--- a/pid1/Cargo.toml
+++ b/pid1/Cargo.toml
@@ -14,9 +14,9 @@ categories = ["command-line-utilities"]
 
 [dependencies]
 nix = { version = "0.29.0", features = ["process", "signal"] }
-signal-hook = "0.3.17"
+signal-hook = "0.3.18"
 thiserror = "1"
 
 [dev-dependencies]
 rand = "0.8.5"
-tokio = { version = "1.43.0", features = ["macros", "rt-multi-thread", "time"]}
+tokio = { version = "1.46.1", features = ["macros", "rt-multi-thread", "time"]}

--- a/pid1/src/lib.rs
+++ b/pid1/src/lib.rs
@@ -100,9 +100,6 @@ impl Pid1Settings {
             }
             pid1_handling(self, signals, child)
         } else {
-            if self.log {
-                eprintln!("pid1-rs: Process not running as Pid 1: PID {pid}");
-            }
             Ok(())
         }
     }

--- a/pid1/tests/sanity.rs
+++ b/pid1/tests/sanity.rs
@@ -51,10 +51,6 @@ fn sanity_test() {
         stdout.contains(&"pid1-rs: Process running as PID 1"),
         "One process runs as pid1",
     );
-    assert!(
-        stdout.contains(&"pid1-rs: Process not running as Pid 1"),
-        "Child process not running as pid1",
-    );
 }
 
 #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.82.0"
+channel = "1.88.0"


### PR DESCRIPTION
Removed an `eprintln!` statement that logged when the process was not running as PID 1. Observing the recent health-check logs, I find this redundant, un-necessary and in some cases confusing.

The whole purpose of these logs is to ensure that the Devops engineer is able to confirm that the application is being run as PID 1 and something else is not configured as entry point in the docker container. We already provide logs when it is currently run as PID 1. Right now, when `pid1` library relaunch the process - it's is launched as a child process and they log these extra message (eg: pid1-rs: Process not running as Pid 1) which makes it confusing since we see series of logs saying it is running as pid 1 and then sdaying it's not running as pid 1. This PR should hopefully improve the current state.