### PR TITLE
refactor: `pid1-exe`

### DIFF
--- a/Development.md
+++ b/Development.md
@@ -17,14 +17,13 @@ The [`pid1/examples` directory](./pid1/examples) contains several programs used 
 
   ```console
   $ just exec-shell
-  $ docker exec -it pid1rs sh
 
+  # docker exec -it pid1rs sh
   $ ps aux
   PID   USER     TIME  COMMAND
       1 root      0:05 /simple
       7 root      0:00 /simple
       8 root      0:00 sh
-    14 root      0:00 [date]
     15 root      0:00 ps aux
   ```
 
@@ -35,20 +34,17 @@ The [`pid1/examples` directory](./pid1/examples) contains several programs used 
 ```console
 $ just test
 
-$ docker run --name pid1rs pid1rstest
+# docker run --rm --name pid1rs pid1rstest
 pid1-rs: Process running as PID 1
-pid1-rs: Process not running as Pid 1: PID 7
 In the simple process, going to sleep. Process ID is 7
 Args: ["/simple"]
-Wed Sep 27 08:29:35 UTC 2023
-Wed Sep 27 08:29:37 UTC 2023
-Wed Sep 27 08:29:39 UTC 2023
+pid1-rs: Reaped PID 7
 ```
 
 Ensure that the process exits with a status code of `0`. The test above confirms the following:
 
 - The `simple` program was executed as PID 1.
-- It relaunched itself as PID 7, which then executed various child processes.
+- It relaunched itself as PID 7, before exiting and was then reaped.
 
 ## Zombie process
 
@@ -56,19 +52,12 @@ Ensure that the process exits with a status code of `0`. The test above confirms
 
     ```console
     $ just run-image
-    $ docker rm pid1rs || exit 0
-    pid1rs
 
-    $ docker run --name pid1rs pid1rstest /simple --sleep
+    # docker run --rm --name pid1rs pid1rstest /simple --sleep 20
     pid1-rs: Process running as PID 1
-    pid1-rs: Process not running as Pid 1: PID 7
     In the simple process, going to sleep. Process ID is 7
-    Args: ["/simple", "--sleep"]
-    Wed Sep 27 08:34:57 UTC 2023
-    Wed Sep 27 08:34:59 UTC 2023
-    Wed Sep 27 08:35:01 UTC 2023
-    Going to sleep 500 seconds
-    Wed Sep 27 08:35:03 UTC 2023
+    Args: ["/simple", "--sleep", "20"]
+    Going to sleep 20 seconds
     ```
 
 2. While it's executing, open a new shell and run the recipe to create a zombie process:
@@ -76,7 +65,7 @@ Ensure that the process exits with a status code of `0`. The test above confirms
     ```console
     $ just run-zombie
 
-    $ docker exec pid1rs zombie
+    # docker exec pid1rs zombie
     Process ID is 9
     Parent process: going to sleep and exit
     ```
@@ -84,54 +73,47 @@ Ensure that the process exits with a status code of `0`. The test above confirms
 3. You should see the following logs from the `simple` process, indicating that a process has been reaped:
 
     ```console
-    Wed Sep 27 09:40:56 UTC 2023
-    Reaped pid: 15
+    Reaped PID: 15
     ```
 
 ## Child Exit code status propagation
 
-1. Run the `run-image` recipe:
+1. Run the `run-orphans` recipe:
 
     ```console
     $ just run-image
-    $ docker rm pid1rs || exit 0
-    pid1rs
 
-    $ docker run --name pid1rs pid1rstest /simple --sleep
+    # docker run --rm --name pid1rs pid1rstest /simple --sleep 20 --create-grandchildren
     pid1-rs: Process running as PID 1
-    pid1-rs: Process not running as Pid 1: PID 7
     In the simple process, going to sleep. Process ID is 7
-    Args: ["/simple", "--sleep"]
-    Wed Sep 27 08:34:57 UTC 2023
-    Wed Sep 27 08:34:59 UTC 2023
-    Wed Sep 27 08:35:01 UTC 2023
-    Going to sleep 500 seconds
-    Wed Sep 27 08:35:03 UTC 2023
+    Args: ["/simple", "--sleep", "20", "--create-grandchildren"]
+    Spawning 3 grandchildren processes that will be orphaned.
+    Going to sleep 20 seconds
     ```
 
 2. Run the `exec-shell` recipe and perform the test:
 
     ```console
     $ just exec-shell
-    $ docker exec -it pid1rs sh
+
+    # docker exec -it pid1rs sh
     $ ps -aux
     USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-    root           1  0.0  0.0    996     4 pts/0    Ss+  12:34   0:00 /simple --sleep
-    root           7  0.0  0.0    976     4 pts/0    S+   12:34   0:00 /simple --sleep
-    root           8  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
-    root           9  0.0  0.0   1672  1048 pts/1    Ss   12:34   0:00 sh
-    root          14  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
-    root          15  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
-    root          16  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
-    root          17  0.0  0.0   2460  1608 pts/1    R+   12:34   0:00 ps -aux
+    root           1  0.8  0.0   1048   756 ?        Ss   10:11   0:00 /simple --sleep 20 --create-grandchildren
+    root           7  0.0  0.0   1040   860 ?        S    10:11   0:00 /simple --sleep 20 --create-grandchildren
+    root           8  0.0  0.0      0     0 ?        Z    10:11   0:00 [sleep] <defunct>
+    root           9  0.0  0.0      0     0 ?        Z    10:11   0:00 [sleep] <defunct>
+    root          10  0.0  0.0      0     0 ?        Z    10:11   0:00 [sleep] <defunct>
+    root          11  0.3  0.1   2900  1888 pts/0    Ss   10:11   0:00 sh
+    root          17  0.0  0.1   7072  3068 pts/0    R+   10:11   0:00 ps -aux
 
     $ kill -12 7
     ```
 
-3. Check the logs of the `run-image` recipe to find the exit status code:
+3. Check the logs of the `run-orphans` recipe to find the exit status code:
 
     ```console
-    error: Recipe `run-image` failed on line 21 with exit code 140
+    error: Recipe `run-orphans` failed on line 21 with exit code 140
     ```
 
     The exit code 140 is correct (128 + 12).
@@ -149,12 +131,9 @@ These are the signal codes:
 
     ```console
     $ just sigterm-test
-    $ docker rm pid1rs || exit 0
-    pid1rs
 
-    $ docker run --name pid1rs pid1rstest sigterm_handler
+    # docker run --rm --name pid1rs pid1rstest sigterm_handler
     pid1-rs: Process running as PID 1
-    pid1-rs: Process not running as Pid 1: PID 7
     This APP can be killed by SIGTERM (15)
     ```
 
@@ -182,12 +161,9 @@ This library should be able to forcibly kill such processes.
 
     ```console
     $ just sigloop-test
-    $ docker rm pid1rs || exit 0
-    pid1rs
 
-    $ docker run --name pid1rs pid1rstest sigterm_loop
+    # docker run --rm --name pid1rs pid1rstest sigterm_loop
     pid1-rs: Process running as PID 1
-    pid1-rs: Process not running as Pid 1: PID 7
     This APP ignores SIGTERM (15)
     ```
 

--- a/Development.md
+++ b/Development.md
@@ -1,41 +1,41 @@
 # Testing
 
-All of these tests have been automated in [sanity.rs](./pid1/tests/sanity.rs).
+All of these tests have been automated in [`pid1/tests/sanity.rs`](./pid1/tests/sanity.rs).
 
-The `examples` directory contains several programs used for testing this library.
+The [`pid1/examples` directory](./pid1/examples) contains several programs used for testing this library.
 
 - `simple.rs`: A program that demonstrates the usage of the `pid1-rs` library.
 - `zombie.rs`: Creates a zombie process.
 - `sigterm_handler.rs`: A program that has a `SIGTERM` handler and exits upon receiving the signal.
 - `sigterm_loop.rs`: A buggy program that does not exit on `SIGTERM`.
-- `dumb_shell.rs`: An alternative shell for testing, since `bash`
-  automatically reaps child processes.
+- `dumb_shell.rs`: An alternative shell for testing, since `bash` automatically reaps child processes.
 
 ## Environment setup
 
 - Run the test program via the just recipe: `build-image`
 - You can get shell access to it via the recipe: `exec-shell`
 
-``` shellsession
-❯ just exec-shell
-docker exec -it pid1rs sh
-/ # ps aux
-PID   USER     TIME  COMMAND
-    1 root      0:05 /simple
-    7 root      0:00 /simple
-    8 root      0:00 sh
-   14 root      0:00 [date]
-   15 root      0:00 ps aux
-```
+  ```console
+  $ just exec-shell
+  $ docker exec -it pid1rs sh
+
+  $ ps aux
+  PID   USER     TIME  COMMAND
+      1 root      0:05 /simple
+      7 root      0:00 /simple
+      8 root      0:00 sh
+    14 root      0:00 [date]
+    15 root      0:00 ps aux
+  ```
 
 # Tests
 
 ## Basic functionality
 
-``` shellsession
-❯ just test
-...
-docker run --name pid1rs pid1rstest
+```console
+$ just test
+
+$ docker run --name pid1rs pid1rstest
 pid1-rs: Process running as PID 1
 pid1-rs: Process not running as Pid 1: PID 7
 In the simple process, going to sleep. Process ID is 7
@@ -45,168 +45,165 @@ Wed Sep 27 08:29:37 UTC 2023
 Wed Sep 27 08:29:39 UTC 2023
 ```
 
-Ensure that the process exits with a status code of 0. The test above
-confirms the following:
+Ensure that the process exits with a status code of `0`. The test above confirms the following:
 
 - The `simple` program was executed as PID 1.
 - It relaunched itself as PID 7, which then executed various child processes.
 
 ## Zombie process
 
-``` shellsession
-❯ just run-image
-...
-docker rm pid1rs || exit 0
-pid1rs
-docker run --name pid1rs pid1rstest /simple --sleep
-pid1-rs: Process running as PID 1
-pid1-rs: Process not running as Pid 1: PID 7
-In the simple process, going to sleep. Process ID is 7
-Args: ["/simple", "--sleep"]
-Wed Sep 27 08:34:57 UTC 2023
-Wed Sep 27 08:34:59 UTC 2023
-Wed Sep 27 08:35:01 UTC 2023
-Going to sleep 500 seconds
-Wed Sep 27 08:35:03 UTC 2023
-```
+1. Run the `run-image` recipe:
 
-While it's executing, open a new shell and run the recipe to create a
-zombie process:
+    ```console
+    $ just run-image
+    $ docker rm pid1rs || exit 0
+    pid1rs
 
-``` shellsession
-❯ just run-zombie
-docker exec pid1rs zombie
-Process ID is 9
-Parent process: going to sleep and exit
-```
+    $ docker run --name pid1rs pid1rstest /simple --sleep
+    pid1-rs: Process running as PID 1
+    pid1-rs: Process not running as Pid 1: PID 7
+    In the simple process, going to sleep. Process ID is 7
+    Args: ["/simple", "--sleep"]
+    Wed Sep 27 08:34:57 UTC 2023
+    Wed Sep 27 08:34:59 UTC 2023
+    Wed Sep 27 08:35:01 UTC 2023
+    Going to sleep 500 seconds
+    Wed Sep 27 08:35:03 UTC 2023
+    ```
 
-You should see the following logs from the `simple` process, indicating
-that a process has been reaped:
+2. While it's executing, open a new shell and run the recipe to create a zombie process:
 
-``` shellsession
-...
-Wed Sep 27 09:40:56 UTC 2023
-Reaped pid: 15
-```
+    ```console
+    $ just run-zombie
+
+    $ docker exec pid1rs zombie
+    Process ID is 9
+    Parent process: going to sleep and exit
+    ```
+
+3. You should see the following logs from the `simple` process, indicating that a process has been reaped:
+
+    ```console
+    Wed Sep 27 09:40:56 UTC 2023
+    Reaped pid: 15
+    ```
 
 ## Child Exit code status propagation
 
-- Run the `run-image` recipe:
+1. Run the `run-image` recipe:
 
-``` shellsession
-❯ just run-image
-...
-docker rm pid1rs || exit 0
-pid1rs
-docker run --name pid1rs pid1rstest /simple --sleep
-pid1-rs: Process running as PID 1
-pid1-rs: Process not running as Pid 1: PID 7
-In the simple process, going to sleep. Process ID is 7
-Args: ["/simple", "--sleep"]
-Wed Sep 27 08:34:57 UTC 2023
-Wed Sep 27 08:34:59 UTC 2023
-Wed Sep 27 08:35:01 UTC 2023
-Going to sleep 500 seconds
-Wed Sep 27 08:35:03 UTC 2023
-```
+    ```console
+    $ just run-image
+    $ docker rm pid1rs || exit 0
+    pid1rs
 
-- Run the `exec-shell` recipe and perform the test:
+    $ docker run --name pid1rs pid1rstest /simple --sleep
+    pid1-rs: Process running as PID 1
+    pid1-rs: Process not running as Pid 1: PID 7
+    In the simple process, going to sleep. Process ID is 7
+    Args: ["/simple", "--sleep"]
+    Wed Sep 27 08:34:57 UTC 2023
+    Wed Sep 27 08:34:59 UTC 2023
+    Wed Sep 27 08:35:01 UTC 2023
+    Going to sleep 500 seconds
+    Wed Sep 27 08:35:03 UTC 2023
+    ```
 
-``` shellsession
-❯ just exec-shell
-docker exec -it pid1rs sh
-/ # ps -aux
-USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
-root           1  0.0  0.0    996     4 pts/0    Ss+  12:34   0:00 /simple --sleep
-root           7  0.0  0.0    976     4 pts/0    S+   12:34   0:00 /simple --sleep
-root           8  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
-root           9  0.0  0.0   1672  1048 pts/1    Ss   12:34   0:00 sh
-root          14  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
-root          15  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
-root          16  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
-root          17  0.0  0.0   2460  1608 pts/1    R+   12:34   0:00 ps -aux
-/ # kill -12 7
-```
+2. Run the `exec-shell` recipe and perform the test:
 
-- Check the logs of the `run-image` recipe to find the exit status
-  code:
+    ```console
+    $ just exec-shell
+    $ docker exec -it pid1rs sh
+    $ ps -aux
+    USER         PID %CPU %MEM    VSZ   RSS TTY      STAT START   TIME COMMAND
+    root           1  0.0  0.0    996     4 pts/0    Ss+  12:34   0:00 /simple --sleep
+    root           7  0.0  0.0    976     4 pts/0    S+   12:34   0:00 /simple --sleep
+    root           8  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
+    root           9  0.0  0.0   1672  1048 pts/1    Ss   12:34   0:00 sh
+    root          14  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
+    root          15  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
+    root          16  0.0  0.0      0     0 pts/0    Z+   12:34   0:00 [date] <defunct>
+    root          17  0.0  0.0   2460  1608 pts/1    R+   12:34   0:00 ps -aux
 
-``` shellsession
-...
-error: Recipe `run-image` failed on line 21 with exit code 140
-```
+    $ kill -12 7
+    ```
 
-The exit code 140 is correct (128 + 12).
+3. Check the logs of the `run-image` recipe to find the exit status code:
 
-## SIGINT/SIGTERM handling
+    ```console
+    error: Recipe `run-image` failed on line 21 with exit code 140
+    ```
 
-The goal of this test is to verify that the child process's `SIGTERM`
-handler is called if it is defined.
+    The exit code 140 is correct (128 + 12).
+
+## SIGINT / SIGTERM handling
+
+The goal of this test is to verify that the child process's `SIGTERM` handler is called if it is defined.
 
 These are the signal codes:
 
-- SIGINT: 2
-- SIGTERM: 15
+- `SIGINT`: 2
+- `SIGTERM`: 15
 
-Execute the recipe `sigterm-test`:
+1. Execute the recipe `sigterm-test`:
 
-``` shellsession
-❯ just sigterm-test
-docker rm pid1rs || exit 0
-pid1rs
-docker run --name pid1rs pid1rstest sigterm_handler
-pid1-rs: Process running as PID 1
-pid1-rs: Process not running as Pid 1: PID 7
-This APP can be killed by SIGTERM (15)
-```
+    ```console
+    $ just sigterm-test
+    $ docker rm pid1rs || exit 0
+    pid1rs
 
-Now, send `SIGTERM` to the PID 1 process:
+    $ docker run --name pid1rs pid1rstest sigterm_handler
+    pid1-rs: Process running as PID 1
+    pid1-rs: Process not running as Pid 1: PID 7
+    This APP can be killed by SIGTERM (15)
+    ```
 
-``` shellsession
-❯ just send-sigterm
-```
+2. Now, send `SIGTERM` to the PID 1 process:
 
-Confirm from the logs that the `SIGTERM` handler was called and that
-the process exited with a status of 0:
+    ```shell
+    just send-sigterm
+    ```
 
-``` shellsession
-App got SIGTERM 15, going to exit
-```
+3. Confirm from the logs that the `SIGTERM` handler was called and that the process exited with a status of `0`:
 
-Now, perform the same test with `SIGINT`. You can confirm that nothing
-is printed, as this signal is not handled by the application.
+    ```console
+    App got SIGTERM 15, going to exit
+    ```
+
+Now, perform the same test with `SIGINT`. You can confirm that nothing is printed,
+as this signal is not handled by the application.
 
 ## SIGTERM ignore
 
-This test is for an application that ignores `SIGTERM` and continues
-running. This library should be able to forcibly kill such processes.
+This test is for an application that ignores `SIGTERM` and continues running.
+This library should be able to forcibly kill such processes.
 
-Execute the recipe `sigloop-test`:
+1. Execute the recipe `sigloop-test`:
 
-``` shellsession
-❯ just sigloop-test
-docker rm pid1rs || exit 0
-pid1rs
-docker run --name pid1rs pid1rstest sigterm_loop
-pid1-rs: Process running as PID 1
-pid1-rs: Process not running as Pid 1: PID 7
-This APP ignores SIGTERM (15)
-```
+    ```console
+    $ just sigloop-test
+    $ docker rm pid1rs || exit 0
+    pid1rs
 
-Now, send `SIGTERM` to the PID 1 process:
+    $ docker run --name pid1rs pid1rstest sigterm_loop
+    pid1-rs: Process running as PID 1
+    pid1-rs: Process not running as Pid 1: PID 7
+    This APP ignores SIGTERM (15)
+    ```
 
-``` shellsession
-❯ just send-sigterm
-```
+2. Now, send `SIGTERM` to the PID 1 process:
 
-You will see that it would have exited:
+    ```shell
+    just send-sigterm
+    ```
 
-``` shellsession
-App got SIGTERM 15, but will not exit
-App got SIGTERM 15, but will not exit
-error: Recipe `sigloop-test` failed on line 44 with exit code 137
-```
+3. You will see that it would have exited:
 
-You can confirm from the status code (137) that the child process was
-killed by `SIGKILL` (signal 9, exit code 128 + 9), because the
-application ignored `SIGTERM`.
+    ```console
+    App got SIGTERM 15, but will not exit
+    App got SIGTERM 15, but will not exit
+    error: Recipe `sigloop-test` failed on line 44 with exit code 137
+    ```
+
+You can confirm from the status code (137) that the child process was killed by
+`SIGKILL` (signal 9, exit code 128 + 9), because the application ignored `SIGTERM`.

--- a/Development.md
+++ b/Development.md
@@ -35,7 +35,7 @@ PID   USER     TIME  COMMAND
 ``` shellsession
 ❯ just test
 ...
-docker run --name pid1rs -t pid1rstest
+docker run --name pid1rs pid1rstest
 pid1-rs: Process running as PID 1
 pid1-rs: Process not running as Pid 1: PID 7
 In the simple process, going to sleep. Process ID is 7
@@ -58,7 +58,7 @@ confirms the following:
 ...
 docker rm pid1rs || exit 0
 pid1rs
-docker run --name pid1rs -t pid1rstest /simple --sleep
+docker run --name pid1rs pid1rstest /simple --sleep
 pid1-rs: Process running as PID 1
 pid1-rs: Process not running as Pid 1: PID 7
 In the simple process, going to sleep. Process ID is 7
@@ -75,7 +75,7 @@ zombie process:
 
 ``` shellsession
 ❯ just run-zombie
-docker exec -t pid1rs zombie
+docker exec pid1rs zombie
 Process ID is 9
 Parent process: going to sleep and exit
 ```
@@ -98,7 +98,7 @@ Reaped pid: 15
 ...
 docker rm pid1rs || exit 0
 pid1rs
-docker run --name pid1rs -t pid1rstest /simple --sleep
+docker run --name pid1rs pid1rstest /simple --sleep
 pid1-rs: Process running as PID 1
 pid1-rs: Process not running as Pid 1: PID 7
 In the simple process, going to sleep. Process ID is 7
@@ -154,7 +154,7 @@ Execute the recipe `sigterm-test`:
 ❯ just sigterm-test
 docker rm pid1rs || exit 0
 pid1rs
-docker run --name pid1rs -t pid1rstest sigterm_handler
+docker run --name pid1rs pid1rstest sigterm_handler
 pid1-rs: Process running as PID 1
 pid1-rs: Process not running as Pid 1: PID 7
 This APP can be killed by SIGTERM (15)
@@ -187,7 +187,7 @@ Execute the recipe `sigloop-test`:
 ❯ just sigloop-test
 docker rm pid1rs || exit 0
 pid1rs
-docker run --name pid1rs -t pid1rstest sigterm_loop
+docker run --name pid1rs pid1rstest sigterm_loop
 pid1-rs: Process running as PID 1
 pid1-rs: Process not running as Pid 1: PID 7
 This APP ignores SIGTERM (15)

--- a/README.md
+++ b/README.md
@@ -109,22 +109,25 @@ CMD [ "your-application", "--arg1" ]
 
 The `pid1` binary supports various command-line options:
 
-``` shellsession
+```shellsession
 ❯ pid1 --help
-Usage:
+A Unix PID1 process wrapper for signal handling and zombie reaping
+
+Usage: pid1 [OPTIONS] <COMMAND> [ARGS]...
 
 Arguments:
   <COMMAND>  Process to run
-  [ARGS]...  Arguments to the process
+  [ARGS]...  Arguments to that process
 
 Options:
-  -w, --workdir <DIR>        Specify working direcory
-  -t, --timeout <TIMEOUT>    Timeout (in seconds) to wait for child proess to exit [default: 2]
+  -w, --workdir <DIR>        Specify working directory
+  -t, --timeout <SECONDS>    Grace period for stopping before escalating to SIGKILL [default: 2]
   -v, --verbose              Turn on verbose output
-  -e, --env <ENV>            Override environment variables. Can specify multiple times
-  -u, --user-id <USER_ID>    Run command with user ID
-  -g, --group-id <GROUP_ID>  Run command with group ID
+  -e, --env <KEY=VALUE>      Override environment variables. Can specify multiple times
+  -u, --user-id <USER ID>    Run command with user ID
+  -g, --group-id <GROUP ID>  Run command with group ID
   -h, --help                 Print help
+  -V, --version              Print version
 ```
 
 ---

--- a/justfile
+++ b/justfile
@@ -1,36 +1,38 @@
+drun_pid1 := "docker run --rm --name pid pid1runner"
+
 # List all recipies
 default:
     just --list --unsorted
 
 # Build pid binary
 build-release-binary:
-    cargo build --target x86_64-unknown-linux-musl --release
+    cargo build --bin pid1 --release --target {{ arch() }}-unknown-linux-musl
 
 # Build test container
 test: build-release-binary
-    cp target/x86_64-unknown-linux-musl/release/pid1 ./pid1-exe/etc/
-    cd pid1-exe/etc && docker build . -f Dockerfile --tag pid1runner
+    cp target/{{ arch() }}-unknown-linux-musl/release/pid1 ./pid1-exe/etc/
+    docker build --tag pid1runner ./pid1-exe/etc/
 
 # Test docker image
 test-init-image:
-    docker run --rm --interactive --name pid pid1runner ps aux
-    docker run --rm --interactive --name pid pid1runner ls
-    docker run --rm --interactive --name pid pid1runner ls /
-    docker run --rm --interactive --name pid pid1runner id
-    docker run --rm --interactive --name pid pid1runner --workdir=/home  pwd
-    docker run --rm --interactive --name pid pid1runner --env HELLO=WORLD --env=FOO=BYE printenv HELLO FOO
+    {{ drun_pid1 }} ps aux
+    {{ drun_pid1 }} ls
+    {{ drun_pid1 }} ls /
+    {{ drun_pid1 }} id
+    {{ drun_pid1 }} --workdir=/home  pwd
+    {{ drun_pid1 }} --env HELLO=WORLD --env=FOO=BYE printenv HELLO FOO
 
 # Exec init image
 exec-init-image:
-    docker run --rm --name pid --tty --interactive pid1runner sh
+    docker run --rm -it --name pid pid1runner sh
 
 # Build binary for other architectures
 binaries clean='false':
-    cross build --target x86_64-unknown-linux-gnu --release
+    cross build --bin pid1 --release --target x86_64-unknown-linux-gnu
     -{{ clean }} && docker image rm ghcr.io/cross-rs/x86_64-unknown-linux-gnu:0.2.5
-    cross build --target aarch64-unknown-linux-gnu --release
+    cross build --bin pid1 --release --target aarch64-unknown-linux-gnu
     -{{ clean }} && docker image rm ghcr.io/cross-rs/aarch64-unknown-linux-gnu:0.2.5
-    cross build --target aarch64-unknown-linux-musl --release
+    cross build --bin pid1 --release --target aarch64-unknown-linux-musl
     -{{ clean }} && docker image rm ghcr.io/cross-rs/aarch64-unknown-linux-musl:0.2.5
 
 # Copy binaries to artifacts directory

--- a/pid1-exe/Cargo.toml
+++ b/pid1-exe/Cargo.toml
@@ -2,14 +2,13 @@
 name = "pid1-exe"
 version = "0.1.6"
 edition = "2021"
-description = "pid1 handling library for proper signal and zombie reaping of the PID1 process"
+description = "A Unix PID1 process wrapper for signal handling and zombie reaping"
 readme = "../README.md"
 homepage = "https://github.com/fpco/pid1-rs"
 repository = "https://github.com/fpco/pid1-rs"
 license = "MIT"
 keywords = ["cli", "init", "pid1", "process"]
 categories = ["command-line-utilities"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [[bin]]
 name = "pid1"

--- a/pid1-exe/Cargo.toml
+++ b/pid1-exe/Cargo.toml
@@ -20,5 +20,7 @@ clap = { version = "4.5.41", default-features = false, features = [
   "help",
   "std",
 ] }
-pid1 = { version = "0.1.6", path = "../pid1" }
 signal-hook = "0.4.3"
+
+[target.'cfg(unix)'.dependencies]
+pid1 = { version = "0.1.6", path = "../pid1" }

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -1,4 +1,3 @@
-use clap::Parser;
 #[cfg(target_family = "unix")]
 use pid1::Pid1Settings;
 #[cfg(target_family = "unix")]
@@ -12,15 +11,15 @@ use std::os::unix::process::CommandExt;
 use std::time::Duration;
 use std::{str::FromStr, ffi::OsString, path::PathBuf};
 
-#[derive(Parser, Debug, PartialEq)]
+#[derive(clap::Parser, Debug, PartialEq)]
 #[command(version, about, long_about = None)]
 pub(crate) struct Pid1App {
     /// Specify working directory
     #[arg(short, long, value_name = "DIR")]
     pub(crate) workdir: Option<PathBuf>,
 
-    /// Timeout (in seconds) to wait for child process to exit
-    #[arg(short, long, value_name = "TIMEOUT", default_value_t = 2)]
+    /// Grace period for stopping before escalating to SIGKILL
+    #[arg(short, long, value_name = "SECONDS", default_value_t = 2)]
     pub(crate) timeout: u8,
 
     /// Turn on verbose output
@@ -32,18 +31,18 @@ pub(crate) struct Pid1App {
     pub(crate) env: Vec<KeyValue>,
 
     /// Run command with user ID
-    #[arg(short, long, value_name = "USER_ID")]
+    #[arg(short, long, value_name = "USER ID")]
     pub(crate) user_id: Option<u32>,
 
     /// Run command with group ID
-    #[arg(short, long, value_name = "GROUP_ID")]
+    #[arg(short, long, value_name = "GROUP ID")]
     pub(crate) group_id: Option<u32>,
 
     /// Process to run
     #[arg(trailing_var_arg = true)]
     pub(crate) command: String,
 
-    /// Arguments to the process
+    /// Arguments to that process
     pub(crate) args: Vec<String>,
 }
 

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -44,45 +44,44 @@ pub(crate) struct Pid1App {
 
 impl Pid1App {
     pub(crate) fn run(self) -> ! {
-        let mut child = std::process::Command::new(&self.command);
-        let child = child.args(&self.args[..]);
+        let mut cmd = std::process::Command::new(&self.command);
+        cmd.args(&self.args);
 
         if let Some(workdir) = &self.workdir {
-            child.current_dir(workdir);
+            cmd.current_dir(workdir);
         }
         if let Some(user_id) = &self.user_id {
-            child.uid(*user_id);
+            cmd.uid(*user_id);
         }
         if let Some(group_id) = &self.group_id {
-            child.gid(*group_id);
+            cmd.gid(*group_id);
         }
         for KeyValue(key, value) in &self.env {
-            child.env(key, value);
+            cmd.env(key, value);
         }
 
         let pid = std::process::id();
         if pid != 1 {
-            let status = child.exec();
+            let status = cmd.exec();
             eprintln!("execvp failed with: {status:?}");
 
             std::process::exit(1);
-        } else {
-            // Install signal handlers before launching child process
-            let signals = Signals::new([SIGTERM, SIGINT, SIGCHLD]).unwrap();
-            let child = child.spawn();
-            let child = match child {
-                Ok(child) => child,
-                Err(err) => {
-                    eprintln!("pid1: {} spawn failed. Got error: {err}", self.command);
-                    std::process::exit(1);
-                }
-            };
-
-            Pid1Settings::new()
-                .enable_log(self.verbose)
-                .timeout(Duration::from_secs(self.timeout.into()))
-                .pid1_handling(signals, child)
         }
+
+        // CRITICAL: Install signal handlers BEFORE spawning the child.
+        // This prevents a race condition where a fast-failing child sends SIGCHLD 
+        // before we are ready to catch and reap it, creating zombie processes.
+        let signals = Signals::new([SIGTERM, SIGINT, SIGCHLD]).unwrap();
+
+        let child = cmd.spawn().unwrap_or_else(|err| {
+            eprintln!("pid1: {} spawn failed. Got error: {err}", self.command);
+            std::process::exit(1);
+        });
+
+        Pid1Settings::new()
+            .enable_log(self.verbose)
+            .timeout(Duration::from_secs(self.timeout.into()))
+            .pid1_handling(signals, child)
     }
 }
 

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -23,7 +23,7 @@ pub(crate) struct Pid1App {
     pub(crate) timeout: u8,
 
     /// Turn on verbose output
-    #[arg(short, long, default_value_t = false)]
+    #[arg(short, long)]
     pub(crate) verbose: bool,
 
     /// Override environment variables. Can specify multiple times.
@@ -32,18 +32,16 @@ pub(crate) struct Pid1App {
 
     /// Run command with user ID
     #[arg(short, long, value_name = "USER_ID")]
-    user_id: Option<u32>,
+    pub(crate) user_id: Option<u32>,
 
     /// Run command with group ID
     #[arg(short, long, value_name = "GROUP_ID")]
-    group_id: Option<u32>,
+    pub(crate) group_id: Option<u32>,
 
     /// Process to run
-    #[arg(required = true)]
     pub(crate) command: String,
 
     /// Arguments to the process
-    #[arg(required = false)]
     pub(crate) args: Vec<String>,
 }
 

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -14,10 +14,10 @@ use std::{error::Error, ffi::OsString, path::PathBuf};
 
 #[derive(Parser, Debug, PartialEq)]
 pub(crate) struct Pid1App {
-    /// Specify working direcory
+    /// Specify working directory
     #[arg(short, long, value_name = "DIR")]
     pub(crate) workdir: Option<PathBuf>,
-    /// Timeout (in seconds) to wait for child proess to exit
+    /// Timeout (in seconds) to wait for child process to exit
     #[arg(short, long, value_name = "TIMEOUT", default_value_t = 2)]
     pub(crate) timeout: u8,
     /// Turn on verbose output

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -1,13 +1,9 @@
-#[cfg(target_family = "unix")]
 use pid1::Pid1Settings;
-#[cfg(target_family = "unix")]
 use signal_hook::{
     consts::{SIGCHLD, SIGINT, SIGTERM},
     iterator::Signals,
 };
-#[cfg(target_family = "unix")]
 use std::os::unix::process::CommandExt;
-#[cfg(target_family = "unix")]
 use std::time::Duration;
 use std::{str::FromStr, ffi::OsString, path::PathBuf};
 
@@ -47,10 +43,10 @@ pub(crate) struct Pid1App {
 }
 
 impl Pid1App {
-    #[cfg(target_family = "unix")]
     pub(crate) fn run(self) -> ! {
         let mut child = std::process::Command::new(&self.command);
         let child = child.args(&self.args[..]);
+
         if let Some(workdir) = &self.workdir {
             child.current_dir(workdir);
         }
@@ -63,6 +59,7 @@ impl Pid1App {
         for KeyValue(key, value) in &self.env {
             child.env(key, value);
         }
+
         let pid = std::process::id();
         if pid != 1 {
             let status = child.exec();
@@ -86,12 +83,6 @@ impl Pid1App {
                 .timeout(Duration::from_secs(self.timeout.into()))
                 .pid1_handling(signals, child)
         }
-    }
-
-    #[cfg(target_family = "windows")]
-    pub(crate) fn run(self) -> ! {
-        eprintln!("pid1: Not supported on Windows");
-        std::process::exit(1);
     }
 }
 

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -10,7 +10,7 @@ use signal_hook::{
 use std::os::unix::process::CommandExt;
 #[cfg(target_family = "unix")]
 use std::time::Duration;
-use std::{error::Error, ffi::OsString, path::PathBuf};
+use std::{str::FromStr, ffi::OsString, path::PathBuf};
 
 #[derive(Parser, Debug, PartialEq)]
 #[command(version, about, long_about = None)]
@@ -28,8 +28,8 @@ pub(crate) struct Pid1App {
     pub(crate) verbose: bool,
 
     /// Override environment variables. Can specify multiple times.
-    #[arg(short, long, value_parser=parse_key_val::<OsString, OsString>)]
-    pub(crate) env: Vec<(OsString, OsString)>,
+    #[arg(short, long, value_name = "KEY=VALUE")]
+    pub(crate) env: Vec<KeyValue>,
 
     /// Run command with user ID
     #[arg(short, long, value_name = "USER_ID")]
@@ -61,7 +61,7 @@ impl Pid1App {
         if let Some(group_id) = &self.group_id {
             child.gid(*group_id);
         }
-        for (key, value) in &self.env {
+        for KeyValue(key, value) in &self.env {
             child.env(key, value);
         }
         let pid = std::process::id();
@@ -96,16 +96,18 @@ impl Pid1App {
     }
 }
 
-/// Parse a single key-value pair
-fn parse_key_val<T, U>(s: &str) -> Result<(T, U), Box<dyn Error + Send + Sync + 'static>>
-where
-    T: std::str::FromStr,
-    T::Err: Error + Send + Sync + 'static,
-    U: std::str::FromStr,
-    U::Err: Error + Send + Sync + 'static,
-{
-    let pos = s
-        .find('=')
-        .ok_or_else(|| format!("invalid KEY=value: no `=` found in `{s}`"))?;
-    Ok((s[..pos].parse()?, s[pos + 1..].parse()?))
+/// A CLI argument parsed from a `KEY=VALUE` pair.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct KeyValue(OsString, OsString);
+
+impl FromStr for KeyValue {
+    type Err = String;
+
+    /// Parses a CLI flag value into a [`KeyValue`] type.
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let (key, value) = s.split_once('=')
+          .ok_or_else(|| format!("invalid `KEY=VALUE` pair: no `=` found in `{s}`"))?;
+
+        Ok(KeyValue(key.into(), value.into()))
+    }
 }

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -13,6 +13,7 @@ use std::time::Duration;
 use std::{error::Error, ffi::OsString, path::PathBuf};
 
 #[derive(Parser, Debug, PartialEq)]
+#[command(version, about, long_about = None)]
 pub(crate) struct Pid1App {
     /// Specify working directory
     #[arg(short, long, value_name = "DIR")]

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -40,6 +40,7 @@ pub(crate) struct Pid1App {
     pub(crate) group_id: Option<u32>,
 
     /// Process to run
+    #[arg(trailing_var_arg = true)]
     pub(crate) command: String,
 
     /// Arguments to the process

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -17,24 +17,31 @@ pub(crate) struct Pid1App {
     /// Specify working directory
     #[arg(short, long, value_name = "DIR")]
     pub(crate) workdir: Option<PathBuf>,
+
     /// Timeout (in seconds) to wait for child process to exit
     #[arg(short, long, value_name = "TIMEOUT", default_value_t = 2)]
     pub(crate) timeout: u8,
+
     /// Turn on verbose output
     #[arg(short, long, default_value_t = false)]
     pub(crate) verbose: bool,
+
     /// Override environment variables. Can specify multiple times.
     #[arg(short, long, value_parser=parse_key_val::<OsString, OsString>)]
     pub(crate) env: Vec<(OsString, OsString)>,
+
     /// Run command with user ID
     #[arg(short, long, value_name = "USER_ID")]
     user_id: Option<u32>,
+
     /// Run command with group ID
     #[arg(short, long, value_name = "GROUP_ID")]
     group_id: Option<u32>,
+
     /// Process to run
     #[arg(required = true)]
     pub(crate) command: String,
+
     /// Arguments to the process
     #[arg(required = false)]
     pub(crate) args: Vec<String>,

--- a/pid1-exe/src/cli.rs
+++ b/pid1-exe/src/cli.rs
@@ -43,6 +43,12 @@ pub(crate) struct Pid1App {
 }
 
 impl Pid1App {
+    /// Parses CLI arguments from the environment.
+    pub(crate) fn from_cli() -> Self {
+      use clap::Parser;
+      Self::parse()
+    }
+
     pub(crate) fn run(self) -> ! {
         let mut cmd = std::process::Command::new(&self.command);
         cmd.args(&self.args);

--- a/pid1-exe/src/main.rs
+++ b/pid1-exe/src/main.rs
@@ -1,11 +1,10 @@
-#[cfg(target_family = "unix")]
+#[cfg(unix)]
 mod cli;
 
-use clap::Parser;
-
-use crate::cli::Pid1App;
-
 fn main() {
-    let cli = Pid1App::parse();
-    cli.run()
+  #[cfg(unix)]
+  cli::Pid1App::from_cli().run();
+
+  #[cfg(not(unix))]
+  compile_error!("`pid1` is only compatible with Unix-like operating systems.");
 }

--- a/pid1-exe/src/main.rs
+++ b/pid1-exe/src/main.rs
@@ -1,3 +1,4 @@
+#[cfg(target_family = "unix")]
 mod cli;
 
 use clap::Parser;

--- a/pid1-exe/src/main.rs
+++ b/pid1-exe/src/main.rs
@@ -2,9 +2,9 @@
 mod cli;
 
 fn main() {
-  #[cfg(unix)]
-  cli::Pid1App::from_cli().run();
+    #[cfg(unix)]
+    cli::Pid1App::from_cli().run();
 
-  #[cfg(not(unix))]
-  compile_error!("`pid1` is only compatible with Unix-like operating systems.");
+    #[cfg(not(unix))]
+    compile_error!("`pid1` is only compatible with Unix-like operating systems.");
 }

--- a/pid1/justfile
+++ b/pid1/justfile
@@ -20,32 +20,32 @@ build-image:
 # Run test image
 run-image:
 	docker rm pid1rs || exit 0
-	docker run --name pid1rs -t pid1rstest /simple --sleep 20
+	docker run --name pid1rs pid1rstest /simple --sleep 20
 
 # Run zombie in the container
 run-zombie:
-	docker exec -t pid1rs zombie
+	docker exec pid1rs zombie
 
 # Test
 test: build-image
 	docker rm pid1rs || exit 0
-	docker run --name pid1rs -t pid1rstest
+	docker run --name pid1rs pid1rstest
 	cargo test
 
 # Run SIGTERM test
 sigterm-test:
 	docker rm pid1rs || exit 0
-	docker run --name pid1rs -t pid1rstest sigterm_handler
+	docker run --name pid1rs pid1rstest sigterm_handler
 
 # Send SIGTERM to container
 send-sigterm:
-	docker exec -it pid1rs kill 1
+	docker exec pid1rs kill 1
 
 # Run SIGTERM loop test
 sigloop-test:
 	docker rm pid1rs || exit 0
-	docker run --name pid1rs -t pid1rstest sigterm_loop
+	docker run --name pid1rs pid1rstest sigterm_loop
 
-# Exec into that docker container
+# Exec into the `pid1rs` docker container
 exec-shell:
 	docker exec -it pid1rs bash

--- a/pid1/justfile
+++ b/pid1/justfile
@@ -15,12 +15,15 @@ build-image:
 	cp ../target/x86_64-unknown-linux-musl/debug/examples/sigterm_handler etc
 	cp ../target/x86_64-unknown-linux-musl/debug/examples/sigterm_loop etc
 	cp ../target/x86_64-unknown-linux-musl/debug/examples/dumb_shell etc
-	docker build etc -f etc/Dockerfile --tag pid1rstest
+	docker build --tag pid1rstest ./etc/
 
 # Run test image
 run-image:
-	docker rm pid1rs || exit 0
-	docker run --name pid1rs pid1rstest /simple --sleep 20
+	docker run --rm --name pid1rs pid1rstest /simple --sleep 20
+
+# Run orphans image
+run-orphans:
+	docker run --rm --name pid1rs pid1rstest /simple --sleep 20 --create-grandchildren
 
 # Run zombie in the container
 run-zombie:
@@ -28,14 +31,12 @@ run-zombie:
 
 # Test
 test: build-image
-	docker rm pid1rs || exit 0
-	docker run --name pid1rs pid1rstest
+	docker run --rm --name pid1rs pid1rstest
 	cargo test
 
 # Run SIGTERM test
 sigterm-test:
-	docker rm pid1rs || exit 0
-	docker run --name pid1rs pid1rstest sigterm_handler
+	docker run --rm --name pid1rs pid1rstest sigterm_handler
 
 # Send SIGTERM to container
 send-sigterm:
@@ -43,8 +44,7 @@ send-sigterm:
 
 # Run SIGTERM loop test
 sigloop-test:
-	docker rm pid1rs || exit 0
-	docker run --name pid1rs pid1rstest sigterm_loop
+	docker run --rm --name pid1rs pid1rstest sigterm_loop
 
 # Exec into the `pid1rs` docker container
 exec-shell:

--- a/pid1/tests/sanity.rs
+++ b/pid1/tests/sanity.rs
@@ -18,7 +18,6 @@ impl Container {
                 "run",
                 "--name",
                 self.name.as_str(),
-                "-t",
                 self.image.as_str(),
             ])
             .output()
@@ -31,7 +30,7 @@ impl Container {
 
 impl Drop for Container {
     fn drop(&mut self) {
-        // Use rm -f to stop and remove the container. This is robust
+        // Use `rm -f` to stop and remove the container. This is robust
         // and ensures cleanup even if tests fail to stop the container.
         let output = Command::new("docker")
             .args(["rm", "-f", self.name.as_str()])
@@ -72,7 +71,6 @@ fn reaps_zombie_process() {
                 "run",
                 "--name",
                 container.name.as_str(),
-                "-t",
                 container.image.as_str(),
                 "/simple",
                 "--sleep",
@@ -85,7 +83,7 @@ fn reaps_zombie_process() {
 
         let zombie_result = s.spawn(|| {
             let zombie_output = container
-                .plain_run(&["exec", "-t", container.name.as_str(), "zombie"])
+                .plain_run(&["exec", container.name.as_str(), "zombie"])
                 .unwrap();
             zombie_output
         });
@@ -117,7 +115,6 @@ fn child_process_status_code() {
                 "run",
                 "--name",
                 container.name.as_str(),
-                "-t",
                 container.image.as_str(),
                 "/simple",
                 "--sleep",
@@ -144,7 +141,6 @@ fn child_process_status_code() {
             container
                 .plain_run(&[
                     "exec",
-                    "-t",
                     container.name.as_str(),
                     "kill",
                     "-12",
@@ -174,7 +170,6 @@ fn sigterm_handling() {
                 "run",
                 "--name",
                 container.name.as_str(),
-                "-t",
                 container.image.as_str(),
                 "sigterm_handler",
             ]);
@@ -184,7 +179,7 @@ fn sigterm_handling() {
         let kill_result = s.spawn(|| {
             std::thread::sleep(Duration::from_secs(2));
             container
-                .plain_run(&["exec", "-t", container.name.as_str(), "kill", "1"])
+                .plain_run(&["exec", container.name.as_str(), "kill", "1"])
                 .unwrap()
         });
 
@@ -210,7 +205,6 @@ fn sigterm_ignore() {
                 "run",
                 "--name",
                 container.name.as_str(),
-                "-t",
                 container.image.as_str(),
                 "sigterm_loop",
             ]);
@@ -220,7 +214,7 @@ fn sigterm_ignore() {
         let kill_result = s.spawn(|| {
             std::thread::sleep(Duration::from_secs(2));
             container
-                .plain_run(&["exec", "-t", container.name.as_str(), "kill", "1"])
+                .plain_run(&["exec", container.name.as_str(), "kill", "1"])
                 .unwrap()
         });
 
@@ -261,7 +255,6 @@ fn reaps_multiple_zombie_processes() {
                     "run",
                     "--name",
                     container.name.as_str(),
-                    "-t",
                     container.image.as_str(),
                     "/simple",
                     "--sleep",
@@ -294,7 +287,6 @@ fn reaps_multiple_zombie_processes() {
         let zombie_check_output = container
             .plain_run(&[
                 "exec",
-                "-t",
                 container.name.as_str(),
                 "sh",
                 "-c",
@@ -351,7 +343,6 @@ fn reaps_orphaned_grandchildren() {
             "run",
             "--name",
             container.name.as_str(),
-            "-t",
             container.image.as_str(),
             "/simple",
             "--create-grandchildren",


### PR DESCRIPTION
This PR is only applying changes to the `pid1-exe` package, I've avoided touching the library until feedback of this PR is received.

- Originally, I just wanted to correct some typos, and improve the `--help` output. I tidied up the CLI code a bit along the way, it should not introduce any regressions.
- Commit history is reasonably clean, but not ideal. Given PR history in the project thus far, if you're comfortable with the PR being squashed to a single commit with a reference to this PR for context, please use "Squash" as the merge strategy (_rather than the default "Merge commit"_).

## Functional changes (_beyond `--help` output_)

- `--` is now optional, the `clap` parser won't swallow options from the RHS of the `command` positional arg.
- Refuse to compile on Windows (_or any other non-unix platform_).
  - `Cargo.toml` now restricts the `pid1` dep to unix platforms only. As the other deps are cross-platform, it's best practice AFAIK to leave those without a constraint (_thus they are downloaded/compiled_), even though the CLI itself will fail to compile.
  - Compilation for Windows now fails like so:

    ```console
    $ cargo +stable zigbuild --quiet --bin pid1 --release --target x86_64-pc-windows-gnu

    Compiling pid1-exe v0.1.6 (/opt/pid1-rs/pid1-exe)
    error: `pid1` is only compatible with Unix-like operating systems.
     --> pid1-exe/src/main.rs:9:3
      |
    9 |   compile_error!("`pid1` is only compatible with Unix-like operating systems.");
      |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

    error: could not compile `pid1-exe` (bin "pid1") due to 1 previous error
    ```
  - The prior "implementation" seemed rather misleading? For which no context was available on related PRs where these additions slipped in (_presumably the intent was to avoid noisy compile errors?_):
    - https://github.com/fpco/pid1-rs/pull/7 (lib)
    - https://github.com/fpco/pid1-rs/pull/11 (bin)


## `--help` output comparison

**`0.1.6`:**

```
Usage:

Arguments:
  <COMMAND>  Process to run
  [ARGS]...  Arguments to the process

Options:
  -w, --workdir <DIR>        Specify working direcory
  -t, --timeout <TIMEOUT>    Timeout (in seconds) to wait for child proess to exit [default: 2]
  -v, --verbose              Turn on verbose output
  -e, --env <ENV>            Override environment variables. Can specify multiple times
  -u, --user-id <USER_ID>    Run command with user ID
  -g, --group-id <GROUP_ID>  Run command with group ID
  -h, --help                 Print help
```

**Revised via this PR:**

```
A Unix PID1 process wrapper for signal handling and zombie reaping

Usage: pid1 [OPTIONS] <COMMAND> [ARGS]...

Arguments:
  <COMMAND>  Process to run
  [ARGS]...  Arguments to that process

Options:
  -w, --workdir <DIR>        Specify working directory
  -t, --timeout <SECONDS>    Grace period for stopping before escalating to SIGKILL [default: 2]
  -v, --verbose              Turn on verbose output
  -e, --env <KEY=VALUE>      Override environment variables. Can specify multiple times
  -u, --user-id <USER ID>    Run command with user ID
  -g, --group-id <GROUP ID>  Run command with group ID
  -h, --help                 Print help
  -V, --version              Print version
```

**Diff from `0.1.6`:**
- Added program description and usage syntax
- `--workdir` description typo `direcory` => `directory`
- --timeout` description typo ~~`proess` => `process`~~ (_**EDIT:** Revised description entirely_)
- `--env` option value format communicates expected structure
- Added `--version` option

## Full change overview

The diff should be fairly straight-forward, but if additional context for anything is needed, hopefully this documents my reasoning well enough 😅 

- Removed `cfg` attributes for conditional compilation (_along with `windows` compilation "support"_).
  - Only `unix` platforms are actually supported, make that explicit with an compilation failure on unsupported platforms. `compile_error!` is used for a friendly failure message.
  - `#[cfg(target_family = "unix")]` shortened to alias `#[cfg(unix)]`
- The `clap:usage` crate feature was added for generating the usage in `--help` output, previously this was blank. Alternatively it could be set with a hard-coded string if not adding the `usage` feature.
- **`Pid1App` refactored:**
  - Corrected typos in doc comments and introduced white-space for improved readability.
  - When [`user_id`/`group_id`](https://github.com/fpco/pid1-rs/pull/16) were added, they were excluded from `pub(crate)` visibility already established on other fields in the struct. Added for consistency.
  - The `command` attribute annotating the struct adds a `--version` option and [`about`](https://docs.rs/clap/latest/clap/struct.Command.html#method.about) (`-h`/`--help`) that sources `description` from `Cargo.toml`. The existing description in `Cargo.toml` was not accurate, I iterated through a few variations before settling on the one committed, though I'm not sure how well "signal handling" maps to what is effectively only support for graceful exit? (_`SIGCHLD` aside for zombie reaping_)
  - `--timeout` description revised to more clearly communicate it's a grace period that escalates to `SIGKILL`, rather than just a timeout on the child process exiting without context to an outcome.
  - `arg` attributes adjusted to remove implicit defaults. Additionally `--env` + `--timeout` have more helpful contextual `value_name` set, while `--user-id`/`--group-id` remove the `_` (_the previous values here were implicit already from the field name_).
  - The `command` field `arg` attribute now has [`trailing_var_arg = true`](https://docs.rs/clap/latest/clap/struct.Arg.html#method.trailing_var_arg).
    - The `--` separator is now optional between the wrapped `command` and `pid1-exe` CLI options.
    - Previously without `--`, `clap` would treat anything other than positional args on the RHS of `command` parsed as part of the `pid1-exe` options (eg: `--help`).
    - `--env` removed the `value_parser` in favor of a `impl FromStr` and wrapper type `KeyValue(OsString, OsString)` instead of `(OsString, OsString)`.
      - The main benefit for this is simpler logic )(_and as a bonus, simpler interoperability with other CLI crates such as `bpaf`_).
      - **NOTE:** Adapted the [`KeyValue` type from the `wasmi` project](https://github.com/wasmi-labs/wasmi/blob/592751e847169936e5bb5d253f07bf332266c847/crates/cli/src/commands/run.rs#L293-L341) `clap` CLI (_which in an earlier iteration had a [familiar looking error string](https://github.com/wasmi-labs/wasmi/pull/1791/changes#diff-283bcf224f3a9c763875b6cf6b6bebf08a4ad648068f14485198f76fb918ef8aR32)_).
- **`Pid1App::run()` refactored:**
  - Introduced white-space formatting for better readability / maintainability.
  - `child` => `cmd` for the `let` binding that's actually the configured/parsed command to execute. There's also no need for the rebinding directly after to set the args. The args can use the `Vec` type as-is instead of slice syntax (_the vec is casted implicitly to a slice_).
  - Expanded on the signal install comment, I was a bit curious about it but the only context from `git blame` was [potential race condition](https://github.com/fpco/pid1-rs/pull/11) without any other details.
    - This could technically be shifted to occur prior to the `pid != 1` condition, but registering the signals is only relevant when `pid == 1`, so would be redundant (_given the `exec`/`exit` paths_).
    - Personally since this logic has a variation in the `pid1` lib, it seems more appropriate to have a convenience in the lib for a CLI to call, simplifying any CLI implementation.
  - Some control flow was adjusted to reduce the nested indentation.
    - `pid != 1` conditional does not need to wrap subsequent logic in an `else` branch, as it already performs `exec` into the command, with process exit if that fails.
      - I considered adding a comment for clarity that when not running as PID1 that zombie reaping and signal propagation from `pid1` lib was of no value, but could not express such tersely without language that was already similarly conveyed in the small logic for that branch 😅 (_thus assumed reader is familiar with why_)
      - I somewhat expected a log when `--verbose` was used to highlight when not PID1, I think `tini`/`dumb-init` can do such. I could add a follow-up PR addressing that.
    - There's no need for the double `let child` binding with `.spawn()` + `match { ... }`? Simplified to using `.spawn().unwrap_or_else( ... )`.